### PR TITLE
클라이언트가 이중으로 소켓에 연결하는 문제 해결

### DIFF
--- a/src/components/3d/Mesh/OtherSquid.jsx
+++ b/src/components/3d/Mesh/OtherSquid.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Html, useGLTF } from '@react-three/drei';
+import { Html, Clone, useGLTF } from '@react-three/drei';
 
 const OtherSquid = React.memo(({ nickname, pos }) => {
   console.log(nickname, pos);

--- a/src/components/3d/Mesh/Squid.jsx
+++ b/src/components/3d/Mesh/Squid.jsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
-import { useGLTF, Html, useKeyboardControls } from '@react-three/drei';
+import { Clone, useGLTF, Html, useKeyboardControls } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
 
 const Squid = React.memo(({ nickname, socket }) => {


### PR DESCRIPTION
**작업 내용**

- 클라이언트의 소켓 연결 로직(`io([url]`)을 useEffect 내부로 이동해 컴포넌트가 마운트 될 때 한번만 소켓에 연결하도록 하였습니다.
```
Client connected: aarqrumQi9yHH9G2AAAB // 1번 클라이언트
4100님이 코드: 1방에 접속했습니다. aarqrumQi9yHH9G2AAAB
room {}
message { x: 0, y: 0, z: 0 } aarqrumQi9yHH9G2AAAB
Client connected: pCmXy7jlcjWVxAiTAAAD // 2번 클라이언트
3290님이 코드: 1방에 접속했습니다. pCmXy7jlcjWVxAiTAAAD
room { aarqrumQi9yHH9G2AAAB: [ 4100, { x: 0, y: 0, z: 0 } ] }
```

**관련 이슈**

- #8 클라이언트 이중 연결 문제