### PR TITLE
클라이언트 위치 갱신 로직 단순화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-three/fiber": "8.16",
         "@react-three/rapier": "1.3",
         "axios": "^1.7.2",
+        "dotenv": "^16.4.5",
         "r3f-perf": "7.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2268,6 +2269,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/draco3d": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-three/fiber": "8.16",
     "@react-three/rapier": "1.3",
     "axios": "^1.7.2",
+    "dotenv": "^16.4.5",
     "r3f-perf": "7.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,8 +1,7 @@
 import axios from 'axios';
 import useAuthStore from '../store/authStore';
 
-// const baseURL = process.env.REACT_APP_API_URL || 'http://192.168.0.98:8080';
-const baseURL = 'http://localhost:8080';
+const baseURL = import.meta.env.REACT_APP_API_URL || 'http://localhost:8080';
 
 const api = axios.create({
   baseURL: baseURL,

--- a/src/components/3d/Mesh/Character.jsx
+++ b/src/components/3d/Mesh/Character.jsx
@@ -15,7 +15,9 @@ const Character = React.memo(({ path, matName, nickname, actionType }) => {
 
     // stop action
     return () => {
-      actions[actionType].fadeOut(0.5);
+      if (actions[actionType]) {
+        actions[actionType].fadeOut(0.5);
+      }
     };
   }, [actionType]);
 
@@ -29,15 +31,17 @@ const Character = React.memo(({ path, matName, nickname, actionType }) => {
             material={materials[matName]}
             skeleton={nodes.Mesh.skeleton}
             scale={2}
+            frustumCulled={false}
           />
           <primitive object={nodes.root} />
           <Html
             position={[0, 3, 0]}
             wrapperClass="label"
             center
-            distanceFactor={8}
+            distanceFactor={10}
+            scale={200}
           >
-            👤 {nickname}
+            {nickname}
           </Html>
         </group>
       </group>

--- a/src/components/3d/Mesh/CharacterController.jsx
+++ b/src/components/3d/Mesh/CharacterController.jsx
@@ -1,150 +1,157 @@
-import React, { useRef, useEffect, useState } from 'react';
-import { useKeyboardControls, CameraControls } from '@react-three/drei';
+import React, { useRef, useEffect, useState, useMemo } from 'react';
+import { useKeyboardControls } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
-import { CapsuleCollider, RigidBody, vec3 } from '@react-three/rapier';
+import { CapsuleCollider, RigidBody, vec3, euler } from '@react-three/rapier';
 import Character from './Character';
 
-const CharacterController = React.memo(
-  ({ path, matName, nickname, socket }) => {
-    const rigidbody = useRef();
-    const character = useRef();
-    const controls = useRef();
+const CharacterController = ({ path, matName, nickname, socket }) => {
+  const rigidbody = useRef(); // 움직임 관리
+  const character = useRef(); // 각도 회전 관리
+  const controls = useRef();
 
-    const [subscribeKeys, getKeys] = useKeyboardControls();
+  const [subscribeKeys, getKeys] = useKeyboardControls();
 
-    // World Position
-    const [myPos, setMyPos] = useState({ x: 0, y: 0, z: 0 });
-    // Action
-    const [action, setAction] = useState('Idle_A');
+  // World Position
+  const [myPos, setMyPos] = useState({ x: 0, y: 0, z: 0 });
+  // Action
+  const [action, setAction] = useState('Idle_A');
 
-    useEffect(() => {
-      rigidbody.current.setTranslation({ x: 0, y: 0, z: 0 });
-    }, []);
-    // 임계점 이상일 때만 렌더링한다.
-    const detectMovement = (oldPos, newPos, threshold = 0.3) => {
-      return (
-        Math.abs(oldPos.x - newPos.x) > threshold ||
-        Math.abs(oldPos.y - newPos.y) > threshold ||
-        Math.abs(oldPos.z - newPos.z) > threshold
-      );
-    };
-
-    // 내 위치가 바뀌면 서버에 위치를 전송한다.
-    useEffect(() => {
-      socket.emit('iMove', { nickName: nickname, position: myPos }); // 보내줄 데이터 {nickName, {x, y, z}}
-    }, [myPos]);
-
-    useEffect(() => {
-      console.log(action);
-    }, [action]);
-
-    const MOVEMENT_SPEED = 50;
-    const JUMP_FORCE = 2;
-    const MAX_LINVEL = 5;
-
-    // 키보드 상하좌우로 움직인다.
-    useFrame(() => {
-      setAction('Idle_A'); // default action
-
-      const { forward, backward, leftward, rightward, jump } = getKeys();
-
-      const impulse = { x: 0, y: 0, z: 0 };
-      const linvel = rigidbody.current.linvel(); // 너무 빨라지지 않도록
-
-      let changeRotation = false;
-
-      if (forward && linvel.z > -MAX_LINVEL) {
-        setAction('Walk');
-        impulse.z -= MOVEMENT_SPEED;
-        changeRotation = true;
-      }
-      if (backward && linvel.z < MAX_LINVEL) {
-        setAction('Walk');
-        impulse.z += MOVEMENT_SPEED;
-        changeRotation = true;
-      }
-      if (leftward && linvel.x > -MAX_LINVEL) {
-        setAction('Walk');
-        impulse.x -= MOVEMENT_SPEED;
-        changeRotation = true;
-      }
-      if (rightward && linvel.x < MAX_LINVEL) {
-        setAction('Walk');
-        impulse.x += MOVEMENT_SPEED;
-        changeRotation = true;
-      }
-      if (jump) {
-        setAction('Jump');
-        impulse.y += JUMP_FORCE;
-      }
-
-      // 바라보는 방향으로 얼굴 돌리기
-      rigidbody.current.applyImpulse(impulse);
-      if (changeRotation) {
-        const angle = Math.atan2(linvel.x, linvel.z);
-        character.current.rotation.y = angle;
-      }
-
-      // rigidbody의 위치로 Position을 업데이트
-      const bodyPos = rigidbody.current.translation();
-
-      const mypos = {
-        x: bodyPos.x,
-        y: bodyPos.y,
-        z: bodyPos.z,
-      };
-
-      if (detectMovement(myPos, mypos)) {
-        // console.log('New pos!', myPos, 'to', mypos);
-        setMyPos(mypos);
-      }
-
-      // camera controls
-      if (controls.current) {
-        const cameraDistanceY = 12;
-        const cameraDistanceZ = 30;
-        const playerWorldPos = vec3(rigidbody.current.translation());
-
-        controls.current.setLookAt(
-          playerWorldPos.x,
-          playerWorldPos.y + cameraDistanceY,
-          playerWorldPos.z + cameraDistanceZ,
-          playerWorldPos.x,
-          playerWorldPos.y + 0.5,
-          playerWorldPos.z,
-          true
-        );
-      }
-    });
-
+  // model loading을 한 번만 수행한다.
+  const model = useMemo(() => {
+    console.log(`Loading model for ${nickname} from ${path}`);
     return (
-      <>
-        {/* <CameraControls ref={controls} /> */}
-        <RigidBody
-          ref={rigidbody}
-          colliders={false}
-          canSleep={false}
-          enabledRotations={[false, false, false]}
-          mass={10}
-          gravityScale={1.6}
-        >
-          {/* collider 내 position: 모델으로부터의 상대적 위치 */}
-          <CapsuleCollider args={[0.5, 0.7]} position={[0, 1.25, 0]} />
-          <group ref={character}>
-            {action && (
-              <Character
-                path={path}
-                matName={matName}
-                nickname={nickname}
-                scale={2}
-                actionType={action}
-              />
-            )}
-          </group>
-        </RigidBody>
-      </>
+      <Character
+        path={path}
+        matName={matName}
+        nickname={nickname}
+        scale={2}
+        actionType="Idle_A"
+      />
     );
-  }
-);
+  }, [path, matName, nickname]);
+
+  // 첫 렌더링 시 스폰 위치
+  useEffect(() => {
+    const defaultPos = {
+      x: 0,
+      y: 0,
+      z: 0,
+    };
+    rigidbody.current.setTranslation(defaultPos);
+    setMyPos(defaultPos);
+  }, []);
+
+  // 임계점 이상일 때만 렌더링한다.
+  const detectMovement = (oldPos, newPos, threshold = 0.3) => {
+    return (
+      Math.abs(oldPos.x - newPos.x) > threshold ||
+      Math.abs(oldPos.y - newPos.y) > threshold ||
+      Math.abs(oldPos.z - newPos.z) > threshold
+    );
+  };
+
+  // 내 위치가 바뀌면 서버에 위치를 전송한다.
+  useEffect(() => {
+    socket.emit('iMove', { nickName: nickname, position: myPos }); // 보내줄 데이터 {nickName, {x, y, z}}
+  }, [myPos]);
+
+  const MOVEMENT_SPEED = 50;
+  const JUMP_FORCE = 2;
+  const MAX_LINVEL = 5;
+
+  // 키보드 상하좌우로 움직인다.
+  useFrame(() => {
+    setAction('Idle_A'); // default action
+
+    const { forward, backward, leftward, rightward, jump } = getKeys();
+
+    const impulse = { x: 0, y: 0, z: 0 };
+    const linvel = rigidbody.current.linvel(); // 너무 빨라지지 않도록
+
+    let changeRotation = false;
+
+    if (forward && linvel.z > -MAX_LINVEL) {
+      setAction('Walk');
+      impulse.z -= MOVEMENT_SPEED;
+      changeRotation = true;
+    }
+    if (backward && linvel.z < MAX_LINVEL) {
+      setAction('Walk');
+      impulse.z += MOVEMENT_SPEED;
+      changeRotation = true;
+    }
+    if (leftward && linvel.x > -MAX_LINVEL) {
+      setAction('Walk');
+      impulse.x -= MOVEMENT_SPEED;
+      changeRotation = true;
+    }
+    if (rightward && linvel.x < MAX_LINVEL) {
+      setAction('Walk');
+      impulse.x += MOVEMENT_SPEED;
+      changeRotation = true;
+    }
+    if (jump) {
+      setAction('Jump');
+      impulse.y += JUMP_FORCE;
+    }
+
+    // rigidbody 위치 이동
+    rigidbody.current.applyImpulse(impulse, true);
+    const newPos = rigidbody.current.translation();
+    rigidbody.current.setTranslation(newPos);
+    if (detectMovement(myPos, newPos)) {
+      setMyPos(newPos);
+    }
+
+    // rigidbody 각도 이동
+    if (changeRotation) {
+      const angle = Math.atan2(impulse.x, impulse.z);
+      character.current.rotation.y = angle;
+    }
+
+    // camera controls
+    if (controls.current) {
+      const cameraDistanceY = 12;
+      const cameraDistanceZ = 30;
+      const playerWorldPos = vec3(rigidbody.current.translation());
+
+      controls.current.setLookAt(
+        playerWorldPos.x,
+        playerWorldPos.y + cameraDistanceY,
+        playerWorldPos.z + cameraDistanceZ,
+        playerWorldPos.x,
+        playerWorldPos.y + 0.5,
+        playerWorldPos.z,
+        true
+      );
+    }
+  });
+
+  return (
+    <>
+      {/* <CameraControls ref={controls} /> */}
+      <RigidBody
+        ref={rigidbody}
+        colliders={false}
+        canSleep={false}
+        enabledRotations={[false, false, false]}
+      >
+        {/* collider 내 position: 모델으로부터의 상대적 위치 */}
+        <CapsuleCollider args={[0.5, 0.7]} position={[0, 1.25, 0]} />
+        <group ref={character}>
+          {action && (
+            <Character
+              path={path}
+              matName={matName}
+              nickname={nickname}
+              scale={2}
+              actionType={action}
+            />
+          )}
+        </group>
+      </RigidBody>
+    </>
+  );
+};
 
 export default CharacterController;

--- a/src/pages/Game.jsx
+++ b/src/pages/Game.jsx
@@ -68,14 +68,17 @@ export default function Game() {
   };
 
   /* 임시 원숭이 배열 */
-  const colobusModels = [
-    'Colobus_Animations2.glb',
-    'Colobus_Animations3.glb',
-    'Colobus_Animations4.glb',
-    'Colobus_Animations5.glb',
-    'Colobus_Animations6.glb',
-    'Colobus_Animations7.glb',
-  ];
+  const colobusModels = useMemo(
+    () => [
+      'Colobus_Animations2.glb',
+      'Colobus_Animations3.glb',
+      'Colobus_Animations4.glb',
+      'Colobus_Animations5.glb',
+      'Colobus_Animations6.glb',
+      'Colobus_Animations7.glb',
+    ],
+    []
+  );
 
   const ROOM_CODE = code;
 
@@ -206,6 +209,7 @@ export default function Game() {
     joinRoom();
   }, [socket, isConnected, ROOM_CODE, nickname]);
 
+  let modelIdx = 0;
   return (
     <>
       {/* debugging tools */}
@@ -237,7 +241,8 @@ export default function Game() {
         {/* others */}
         {isConnected &&
           isJoined &&
-          Object.keys(clientCoords).map((key, modelIdx) => {
+          Object.keys(clientCoords).map(key => {
+            console.log(modelIdx);
             if (key != nickname) {
               return (
                 <OtherCharacterController

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -13,12 +13,10 @@ body,
 .label > div {
   font-family: Helvetica, Arial;
   position: absolute;
-  background: #00000088;
   color: white;
-  padding: 15px;
+  font-size: 70px;
   white-space: nowrap;
   overflow: hidden;
-  border-radius: 30px;
   user-select: none;
 }
 


### PR DESCRIPTION
**작업 내용**
- 기존의 rigidbody와 mesh의 위치를 모두 수정하는 로직에서 rigidbody만 위치를 갱신시키는 방식으로 수정하였습니다.
- 바라보는 방향으로 더욱 빠르게 고개를 돌리도록 수정하였습니다.
- 모델이 렌더링될 때 매번 새로 load하던 기존의 방식에서, 첫 렌더링 시에만 모델을 load하도록 useMemo를 사용하였습니다.

**버그**
- 다른 클라이언트의 고개 각도가 돌아가지 않습니다.