### PR TITLE
퀴즈결과가 계속 오답인 오류 수정

### DIFF
--- a/src/components/common/OXQuizForm/OXQuizForm.jsx
+++ b/src/components/common/OXQuizForm/OXQuizForm.jsx
@@ -4,8 +4,8 @@ import styles from './OXQuizForm.module.css';
 
 const OXQuizForm = ({ register, errors, index }) => {
   const options = [
-    { value: 'O', label: 'O' },
-    { value: 'X', label: 'X' },
+    { value: '1', label: 'O' },
+    { value: '2', label: 'X' },
   ];
   return (
     <div className={styles.quiz}>


### PR DESCRIPTION
- 퀴즈 생성시 결과를 nuber가 아닌 string으로 저장하고 있었습니다. number로 변경했습니다.