### PR TITLE
feat: 양자화 추가

### DIFF
--- a/src/components/3d/Mesh/CharacterController.jsx
+++ b/src/components/3d/Mesh/CharacterController.jsx
@@ -46,6 +46,25 @@ const CharacterController = ({
   // Jump only once
   const [isJumped, setIsJumped] = useState(false);
 
+  const quantize = (value, min, max, bits = 8) => {
+    const range = max - min;
+    const step = range / (Math.pow(2, bits) - 1);
+    return Math.round((value - min) / step);
+  };
+
+  const quantizePosition = (position, bits = 8) => {
+    const ranges = {
+      x: { min: -100, max: 100 },
+      y: { min: -50, max: 50 },
+      z: { min: -50, max: 50 },
+    };
+    return {
+      x: quantize(position.x, ranges.x.min, ranges.x.max, bits),
+      y: quantize(position.y, ranges.y.min, ranges.y.max, bits),
+      z: quantize(position.z, ranges.z.min, ranges.z.max, bits),
+    };
+  };
+
   // 첫 렌더링 시 스폰 위치
   useEffect(() => {
     rigidbody.current.setTranslation(spawn);
@@ -179,7 +198,10 @@ const CharacterController = ({
   // 1/30초마다 수행할 작업을 정의하는 함수
   const performUpdate = () => {
     const newPos = rigidbody.current.translation();
-    socket.emit('iMove', { nickName: nickname, position: newPos }); // 보내줄 데이터 {nickName, {x, y, z}}
+    socket.emit('iMove', {
+      nickName: nickname,
+      position: quantizePosition(newPos),
+    }); // 보내줄 데이터 {nickName, {x, y, z}}
   };
 
   const handleCollision = data => {

--- a/src/utils/socketHandlers.js
+++ b/src/utils/socketHandlers.js
@@ -68,6 +68,24 @@ export const createSocketHandlers = (
     });
   };
 
+  const dequantize = (value, min, max, bits = 8) => {
+    const range = max - min;
+    const step = range / (Math.pow(2, bits) - 1);
+    return value * step + min;
+  };
+
+  const dequantizePosition = (position, bits = 8) => {
+    const ranges = {
+      x: { min: -100, max: 100 },
+      y: { min: -50, max: 50 },
+      z: { min: -50, max: 50 },
+    };
+    return {
+      x: dequantize(position.x, ranges.x.min, ranges.x.max, bits),
+      y: dequantize(position.y, ranges.y.min, ranges.y.max, bits),
+      z: dequantize(position.z, ranges.z.min, ranges.z.max, bits),
+    };
+  };
   // 다른 클라이언트 입장
   // data: {nickName, {0, 0, 0}}
   const handleNewClientPosition = data => {
@@ -110,7 +128,7 @@ export const createSocketHandlers = (
       const newCoords = { ...prevCoords };
       Object.entries(data).forEach(([key, value]) => {
         if (value && value.nickName && value.position) {
-          newCoords[value.nickName] = value.position;
+          newCoords[value.nickName] = dequantizePosition(value.position);
         }
       });
       return newCoords;


### PR DESCRIPTION
클라이언트가 서버로 좌표값을 전송할 때 양자화해서 전송하고, 서버로부터 좌표값을 받을 때 역양자화해서 사용한다. 단, 브로드캐스트 한정으로 양자화 역양자화를 사용한다.